### PR TITLE
feat: add dialog with default content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# myuw-help
+
+This component provides a way to present help/feedback resources and information in a dialog so users can get help quickly, without leaving the page.
+
+## Development and contribution
+
+To run the demo app locally and test the component, run the following commands:
+
+```bash
+$ npm install
+$ npm start
+```
+
+## Usage
+
+Add the following import to your page's `<head>`:
+
+```html
+<link rel="import" href="https://cdn.rawgit.com/myuw-web-components/myuw-help/7cbe3268/myuw-help.html">
+```
+
+Fire the `show-myuw-help` event on the `document.body` when you want the dialog to display (e.g. when your "help" button is clicked):
+
+```js
+function showHelpDialog() {
+    var event = new Event('show-myuw-help');
+    document.body.dispatchEvent(event);
+}
+```
+
+*Note: It is important that you use that exact event name and dispatch the event from the document body. The component sets a listener on the body that listens for the* `show-myuw-help` *event.*
+
+Use the component's HTML tag wherever you want:
+
+```html
+    <myuw-help
+        myuw-help-title="Get help"
+        show-default-content
+        open>
+        <div class="your-div-here" slot="myuw-help-content">
+            Your custom content
+        </div>
+    </myuw-help
+```
+
+### Configurable properties via attributes
+
+- **myuw-help-title**: The title to display at the top of the help dialog
+- **show-default-content**: Include this attribute if you want to include the default UW-Madison-flavored help links.
+- **open**: Only include this attribute if the dialog should be open by default
+
+### Slots
+
+- **myuw-help-content**: Use this slot to insert your own content into the dialog (with whatever markup and styling you want).

--- a/index.html
+++ b/index.html
@@ -4,26 +4,64 @@
             body {
                 padding: 0;
                 margin: 0;
+                background: #e2e2e2;
             }
-        </style>
-        <link rel="import" href="./myuw-help.html">
-        <link rel="import" href="https://unpkg.com/@myuw-web-components/myuw-app-bar/myuw-app-bar.html">
-        <script src="https://unpkg.com/@myuw-web-components/myuw-app-styles/myuw-app-styles.js"></script>
-    </head>
-    <body>
-        <!-- Styles for demo purposes only -->
-        <style>
+            /* Styles for demo purposes only */
             .demo__container {
                 height: 800px;
             }
+            .demo__button-box {
+                margin: 36px 48px;
+            }
+            .demo__help-button {
+                font-size: 22px;
+                padding: 6px 12px;
+                min-width: 84px;
+                min-height: 48px;
+                border-radius: 4px;
+                border-color: transparent;
+                background: #fff;
+                color: #222;
+                box-shadow: 0 1px 3px 0 rgba(0,0,0,0.2), 0 1px 1px 0 rgba(0,0,0,0.14), 0 2px 1px -1px rgba(0,0,0,0.12);
+                transition: all 0.2s cubic-bezier(.25,.8,.25,1);
+            }
+            .demo__help-button:hover {
+                cursor: pointer;
+                box-shadow: 0 4px 10px 0 rgba(0,0,0,0.2);
+                background: rgb(241, 241, 241);
+            }
+            .demo__help-button:focus {
+                outline: none;
+            }
         </style>
+        <!-- Web component polyfill loader -->
+        <script src="https://cdn.rawgit.com/webcomponents/webcomponentsjs/v1/webcomponents-loader.js"></script>
+        <!-- MyUW web components -->
+        <script src="https://cdn.rawgit.com/myuw-web-components/myuw-app-styles/6f62858b/myuw-app-styles.js"></script>
+        <link rel="import" href="https://cdn.rawgit.com/myuw-web-components/myuw-app-bar/86b5c15b/myuw-app-bar.html">
+        <!-- Help and feedback component -->
+        <link rel="import" href="./myuw-help.html">
+    </head>
+
+    <body>
         <myuw-app-bar 
             theme-name="MyUW" 
             app-name="Help and Feedback">
-            <myuw-help slot="myuw-help" icon-color="#fff"></myuw-help>
         </myuw-app-bar>
         <div class="demo__container">
-            
+            <div class="demo__button-box">
+                <button class="demo__help-button" onclick="getHelp()">Click me for help!</button>
+            </div>
         </div>
+        <myuw-help myuw-help-title="Help is on the way!" show-default-content>
+            <p slot="myuw-help-content">Slot content</p>
+        </myuw-help>
     </body>
+
+    <script>
+        function getHelp() {
+            var event = new Event('show-myuw-help');
+            document.body.dispatchEvent(event);
+        }
+    </script>
 </html>

--- a/myuw-help.html
+++ b/myuw-help.html
@@ -15,16 +15,122 @@
             display: none;
         }
 
-        :host(:hover) {
-            background-color: rgba(158,158,158,0.2);
+        :host([show-default-content]) #myuw-help__default-content {
+            display: block;
         }
 
-        :host(:focus) {
-            outline: none;
+        :host([open]) #myuw-help__dialog {
+            opacity: 1;
+            right: 0;
+            top: 20%;
+            transform: translate(-50%,20%) scale(1);
         }
 
-        #myuw-help__button {
-            color: var(--muyw-app-bar-color, #fff);
+        :host([open]) #myuw-help__shadow {
+            opacity: 1;
+            height: 100%;
+        }
+
+        #myuw-help__dialog {
+            max-height: 80%;
+            max-width: 80%;
+            min-width: 300px;
+            height: auto;
+            -webkit-box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
+            box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
+            background-color: #FFFFFF;
+            padding: 22px 24px 12px;
+            margin-top: 0;
+            margin-bottom: 0;
+            margin-left: auto;
+            margin-right: auto;
+            border-radius: 5px;
+            font-family: 'Roboto', Arial, sans-serif; /* TODO: use styles variables */
+            position: absolute;
+            opacity: 0;
+            top: 0;
+            right: 0;
+            -webkit-transition: all .4s cubic-bezier(.25,.8,.25,1);
+            transition: all .4s cubic-bezier(.25,.8,.25,1);
+            z-index: 101;
+        }
+
+        #myuw-help__heading {
+            display: flex;
+            align-content: center;
+            justify-content: space-between;
+        }
+
+        #myuw-help__title {
+            color: rgba(0,0,0,0.8);
+            font-size: 20px;
+            font-weight: 500;
+            line-height: 24px;
+            letter-spacing: 0.03px;
+        }
+
+        #myuw-help__content {
+            font-weight: 400;
+            font-size: 16px;
+            color: rgba(0,0,0,.5);
+            line-height: 24px;    
+            text-align: left;
+            letter-spacing: 0.03px;
+            padding: 8px 0 16px;
+        }
+
+        #myuw-help__default-content {
+            display: none;
+        }
+
+        #myuw-help__default-content ul {
+            margin: 0;
+            padding: 0;
+            list-style-type: none;
+        }
+        #myuw-help__default-content ul li {
+            transition: background 0.4s cubic-bezier(.25,.8,.25,1);
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+            min-height: 38px;
+            height: auto;
+            padding: 0 16px 0 6px;
+        }
+        #myuw-help__default-content ul li:hover {
+            background: rgba(158,158,158,0.2);
+        }
+        #myuw-help__default-content a {
+            text-decoration: none;
+            color: #0479a8; /* TODO: use styles variables */
+            min-height: 38px;
+            line-height: 38px;
+            flex: auto;
+            display: flex;
+            align-items: center;
+        }
+
+        #myuw-help__default-content .material-icons {
+            width: 24px;
+            min-height: 24px;
+            min-width: 24px;
+            margin-right: 12px;
+            color: #434343;
+        }
+
+        #myuw-help__shadow {
+            position: fixed;
+            top: 64px;
+            left: 0;
+            width: 100%;
+            height: 0;
+            opacity: 0;
+            background: rgba(0,0,0,0.3);
+            transition: opacity 0.3s cubic-bezier(.25,.8,.25,1);
+            z-index: 100;
+        }
+
+        #myuw-help__close-button {
             min-width: 48px;
             margin: 0;
             display: inline-block;
@@ -50,14 +156,61 @@
             overflow: hidden;
             -webkit-transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
             transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
+            border-radius: 50%;
+        }
+        #myuw-help__close-button:hover {
+            background-color: rgba(158,158,158,0.2);
+        }
+        #myuw-help__close-button:focus {
+            outline: none;
+        }
+
+        @media all and (min-width: 481px) and (max-width: 840px) {
+            #myuw-help__dialog {
+                width: 400px;
+            }
+        }
+
+        @media all and (min-width: 841px) {
+            #myuw-help__dialog {
+                width: 600px;
+            }
         }
     </style>
-    <button id='myuw-help__button'>
-        <svg id='myuw-help__icon' xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"/>
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
-        </svg>
-    </button>
+    <div id="myuw-help__dialog">
+        <div id="myuw-help__heading">
+            <h1 id="myuw-help__title"></h1>
+            <button id="myuw-help__close-button" aria-label="close dialog">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                    <path d="M0 0h24v24H0z" fill="none"/>
+                </svg>
+            </button>
+        </div>
+        <div id="myuw-help__content">
+            <slot name="myuw-help-content"></slot>
+            <div id="myuw-help__default-content">
+                <ul>
+                    <li>
+                        <a href="tel:608-264-4357">Call the help desk</a>
+                    </li>
+                    <li>
+                        <a href="mailto:help@doit.wisc.edu">Email the help desk</a>
+                    </li>
+                    <li>
+                        <a href="https://it.wisc.edu">Get help another way</a>
+                    </li>
+                    <li>
+                        <a href="https://outages.doit.wisc.edu/">Check the Outages page</a>
+                    </li>
+                    <li>
+                        <a href="https://kb.wisc.edu/">Search the KnowledgeBase</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div id="myuw-help__shadow"></div>
 </template>
 <!--
     MyUW App Bar web component javascript class defition
@@ -78,20 +231,10 @@
 
         static get observedAttributes() {
             return [
-                'icon-color'
+                'myuw-help-title',
+                'open',
+                'show-default-content'
             ];
-        }
-
-        showDialog() {
-            console.log('show the dialog');
-            document.getElementById('myuw-help__click-catcher').style.opacity = '1';
-            document.getElementById('myuw-help__click-catcher').style.height = '100%';
-        }
-
-        closeDialog() {
-            console.log('close the dialog');
-            document.getElementById('myuw-help__click-catcher').style.opacity = '0';
-            document.getElementById('myuw-help__click-catcher').style.height = '0';
         }
 
         /**
@@ -111,40 +254,49 @@
         */
         connectedCallback() {
             // Get all attributes
-            this['icon-color'] = this.getAttribute('icon-color');
+            this['myuw-help-title'] = this.getAttribute('myuw-help-title');
+            this['open'] = this.getAttribute('open');
+            this['show-default-content'] = this.getAttribute('show-default-content');
 
-            var myuwHelpClickCatcher = document.createElement('div');
-            myuwHelpClickCatcher.setAttribute('id', 'myuw-help__click-catcher');
-            myuwHelpClickCatcher.setAttribute('style', `
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 0;
-                opacity: 0;
-                background: rgba(0,0,0,0.3);
-                transition: opacity 0.3s cubic-bezier(.25,.8,.25,1);
-            `);
-            myuwHelpClickCatcher.addEventListener('click', this.closeDialog);
-            document.body.appendChild(myuwHelpClickCatcher);
-
-            // Listen for click events
-            this.shadowRoot.getElementById('myuw-help__button').addEventListener('click', this.showDialog);
-        }  
-
-        /**
-        *   Clean up event listeners if element is removed from the DOM
-        */
-        disconnectedCallback() {
-            document.getElementById('myuw-help__click-catcher').remove();
+            // Listen for close events
+            this.shadowRoot.getElementById('myuw-help__shadow').addEventListener('click', () => {
+                this.setDialogState(false);
+            });
+            this.shadowRoot.getElementById('myuw-help__close-button').addEventListener('click', () => {
+                this.setDialogState(false);
+            });
+            // Listen for open event
+            document.body.addEventListener('show-myuw-help', () => {
+                this.setDialogState();
+            });
         }
 
         /**
         *   Update the component state
         */
         updateComponent() {
-            // Set the icon fill color
-            this.shadowRoot.getElementById('myuw-help__icon').setAttribute('fill', this['icon-color'])
+            this.shadowRoot.getElementById('myuw-help__title').innerHTML = this['myuw-help-title'];
+        }
+
+        setDialogState(newState) {
+            switch(newState) {
+                case false:
+                    this.removeAttribute('open');
+                    break;
+                case true:
+                    this.setAttribute('open', '');
+                    // Focus the dialog window
+                    this.shadowRoot.getElementById('myuw-help__dialog').focus();
+                    break;
+                default:
+                    if (this.hasAttribute('open')) {
+                        this.removeAttribute('open');
+                    } else {
+                        this.setAttribute('open', '');
+                        // Focus the dialog window
+                        this.shadowRoot.getElementById('myuw-help__dialog').focus();
+                    }
+            }
         }
     }
 


### PR DESCRIPTION
**In this PR**:
- Add event listener on the body (listening for `show-myuw-help`)
- Show help dialog (and backdrop) when event is triggered
- Add configurable stuff
    - Properties (title, open, show default content)
    - Slot for custom content ("myuw-help-content")

*Note: Still needs some media query love to get the positioning right. Also would like to add material icons to default content and would prefer to not have default content hard-coded.*

### Demo
![help-feedback](https://user-images.githubusercontent.com/5818702/42052353-23cecad2-7ad4-11e8-90f5-4421545815bb.gif)
