### PR TITLE
Fix positioning calculation and enable custom position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-help versions
 
+## 1.3.0
+
+### Added
+
+* Added support for sending a custom dialog position as part of the `set-myuw-help-position` CustomEvent
+
 ## 1.2.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Include the component's markup on your page:
     </myuw-help>
 ```
 
-Fire the `show-myuw-help` event on the `document` when you want the dialog to display (e.g. when your "help" button is clicked):
+### Trigger dialog manually 
+
+If you aren't using the top bar button (via the `show-button` attribute), fire the `show-myuw-help` event on the `document` when you want the dialog to display (e.g. when your "help" button is clicked):
 
 ```js
 function showHelpDialog() {
@@ -34,7 +36,25 @@ function showHelpDialog() {
 }
 ```
 
-*Note: It is important that you use that exact event name and dispatch the event from the document scope. The component listens for the* `show-myuw-help` *event.*
+### Set up custom positioning
+
+If you want to control the exact positioning of the dialog, you can dispatch a `CustomEvent` called `set-myuw-help-position` with position data like so:
+
+```js
+function showHelpDialog() {
+    var event = new CustomEvent('show-myuw-help', {
+      detail: { // required by CustomEvent spec
+        position: { // "position" required by myuw-help component
+          top: '100px', // "top" required by myuw-help component
+          left: '100px', // "left" required by myuw-help component
+        }
+      }
+    });
+    document.dispatchEvent(event);
+}
+```
+
+*Note: It is important that you use that exact event name and dispatch the event from the document scope. The component listens for the* `show-myuw-help`  *and* `set-myuw-help-position` *events.*
 
 ### Configurable properties via attributes
 

--- a/index.html
+++ b/index.html
@@ -65,14 +65,27 @@
         <div class="demo__container">
             <div class="demo__button-box">
                 <button class="demo__help-button" onclick="getHelp()">You can also click me for help!</button>
+                <button class="demo__help-button" onclick="setCustomPosition()">Use a custom position</button>
             </div>
         </div>
     </body>
 
     <script>
-        function getHelp() {
-            var event = new Event('show-myuw-help');
-            document.dispatchEvent(event);
-        }
+      function setCustomPosition () {
+        var event = new CustomEvent('set-myuw-help-position', {
+          detail: {
+            position: {
+              left: '100px',
+              top: '100px'
+            }
+          }
+        });
+        document.dispatchEvent(event);
+      }
+
+      function getHelp() {
+        var event = new Event('show-myuw-help');
+        document.dispatchEvent(event);
+      }
     </script>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "",
   "module": "dist/myuw-help.min.mjs",
   "browser": "dist/myuw-help.min.js",

--- a/src/myuw-help.html
+++ b/src/myuw-help.html
@@ -161,13 +161,21 @@
 
     #myuw-help__close-button {
         min-width: 48px;
+        max-width: 48px;
+        min-height: 48px;
+        max-height: 48px;
         margin: 0;
-        display: inline-block;
+        display: flex;
+        -webkit-box-pack: center;
+        -ms-flex-pack: center;
+        -webkit-box-align: center;
+        -ms-flex-line-pack: center;
+        -ms-flex-align: center;
+	      justify-content:center;
+        align-content: center;
+        align-items: center;
         position: relative;
         cursor: pointer;
-        min-height: 36px;
-        line-height: 36px;
-        text-align: center;
         border-radius: 3px;
         box-sizing: border-box;
         -webkit-user-select: none;


### PR DESCRIPTION
**In this PR:**
- Ensure css position attributes are correctly applied
- Add new event to set custom position in cases where default position is not ideal (`set-myuw-help-position`)
- Fix bug where the "close dialog" button was sometimes misaligned

*Tested in Chrome, Firefox, Safari, and IE11*