### PR TITLE
Create a focus trap on Help Dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/node_modules/
+# *.swp
 /dist/
+/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "module": "dist/myuw-help.min.mjs",
   "browser": "dist/myuw-help.min.js",

--- a/src/myuw-help.html
+++ b/src/myuw-help.html
@@ -1,290 +1,296 @@
-
 <style>
-    :host {
-      display: flex;
-      font-style: inherit;
-      font-variant: inherit;
-      font-family: inherit;
-    }
+  :host {
+    display: flex;
+    font-style: inherit;
+    font-variant: inherit;
+    font-family: inherit;
+  }
 
-    :host([hidden]) {
-        display: none;
-    }
+  :host([hidden]) {
+    display: none;
+  }
 
-    :host([show-default-content]) #myuw-help__default-content {
-        display: block;
-    }
+  :host([show-default-content]) #myuw-help__default-content {
+    display: block;
+  }
 
-    :host([show-button]) #help-button {
-      display: flex;
-    }
+  :host([show-button]) #help-button {
+    display: flex;
+  }
 
-    :host([open]) #myuw-help__dialog {
-        opacity: 1;
-        display: block;
-    }
+  :host([open]) #myuw-help__dialog {
+    opacity: 1;
+    display: block;
+  }
 
-    :host([open]) #myuw-help__shadow {
-        opacity: 1;
-        height: 100%;
-    }
+  :host([open]) #myuw-help__shadow {
+    opacity: 1;
+    height: 100%;
+  }
 
-    /* Duplicate styles to appease firefox */
-    myuw-help {
-      display: flex;
-      font-style: inherit;
-      font-variant: inherit;
-      font-family: inherit;
-    }
+  /* Duplicate styles to appease firefox */
+  myuw-help {
+    display: flex;
+    font-style: inherit;
+    font-variant: inherit;
+    font-family: inherit;
+  }
 
-    myuw-help[hidden] {
-        display: none;
-    }
+  myuw-help[hidden] {
+    display: none;
+  }
 
-    myuw-help[show-default-content] #myuw-help__default-content {
-        display: block;
-    }
+  myuw-help[show-default-content] #myuw-help__default-content {
+    display: block;
+  }
 
-    myuw-help[show-button] #help-button {
-      display: flex;
-    }
+  myuw-help[show-button] #help-button {
+    display: flex;
+  }
 
-    myuw-help[open] #myuw-help__dialog {
-        opacity: 1;
-        display: block;
-    }
+  myuw-help[open] #myuw-help__dialog {
+    opacity: 1;
+    display: block;
+  }
 
-    myuw-help[open] #myuw-help__shadow {
-        opacity: 1;
-        /* height: 100%; */
-    }
+  myuw-help[open] #myuw-help__shadow {
+    opacity: 1;
+    /* height: 100%; */
+  }
 
+  #myuw-help__dialog {
+    display: none;
+    max-width: 80%;
+    min-width: 300px;
+    height: auto;
+    -webkit-box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
+    box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
+    background-color: #FFFFFF;
+    padding: 22px 24px 12px;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: auto;
+    margin-right: auto;
+    border-radius: 5px;
+    font-family: var(--myuw-font, 'Roboto', Arial, sans-serif);
+    opacity: 0;
+    position: absolute;
+    float: left;
+    top: 0;
+    right: -1000px;
+    -webkit-transition: all .4s cubic-bezier(.25, .8, .25, 1);
+    transition: all .4s cubic-bezier(.25, .8, .25, 1);
+    z-index: 101;
+  }
+
+  #myuw-help__heading {
+    display: flex;
+    align-content: center;
+    justify-content: space-between;
+  }
+
+  #myuw-help__title {
+    color: rgba(0, 0, 0, 0.8);
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 24px;
+    letter-spacing: 0.03px;
+  }
+
+  #myuw-help__content {
+    font-weight: 400;
+    font-size: 16px;
+    color: rgba(0, 0, 0, .8);
+    line-height: 24px;
+    text-align: left;
+    letter-spacing: 0.03px;
+    padding: 8px 0 16px;
+  }
+
+  #myuw-help__default-content ul {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  #myuw-help__default-content ul li {
+    transition: background 0.4s cubic-bezier(.25, .8, .25, 1);
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    min-height: 38px;
+    height: auto;
+    padding: 0 16px 0 6px;
+  }
+
+  #myuw-help__default-content ul li:hover {
+    background: rgba(158, 158, 158, 0.2);
+  }
+
+  #myuw-help__default-content a {
+    text-decoration: none;
+    color: #0479a8;
+    /* TODO: use styles variables */
+    min-height: 38px;
+    line-height: 38px;
+    flex: auto;
+    display: flex;
+    align-items: center;
+  }
+
+  #myuw-help__default-content .material-icons {
+    width: 24px;
+    min-height: 24px;
+    min-width: 24px;
+    margin-right: 12px;
+    color: #434343;
+  }
+
+  #myuw-help__shadow {
+    position: fixed;
+    top: 64px;
+    left: 0;
+    width: 100%;
+    height: 0;
+    opacity: 0;
+    background: rgba(0, 0, 0, 0.3);
+    transition: opacity 0.3s cubic-bezier(.25, .8, .25, 1);
+    z-index: 100;
+  }
+
+  #myuw-help__close-button {
+    min-width: 48px;
+    max-width: 48px;
+    min-height: 48px;
+    max-height: 48px;
+    margin: 0;
+    display: flex;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-box-align: center;
+    -ms-flex-line-pack: center;
+    -ms-flex-align: center;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    border-radius: 3px;
+    box-sizing: border-box;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    border: 0;
+    padding: 0 6px;
+    background: transparent;
+    white-space: nowrap;
+    text-transform: uppercase;
+    font-weight: 500;
+    font-size: 14px;
+    text-decoration: none;
+    overflow: hidden;
+    -webkit-transition: box-shadow .4s cubic-bezier(.25, .8, .25, 1), background-color .4s cubic-bezier(.25, .8, .25, 1);
+    transition: box-shadow .4s cubic-bezier(.25, .8, .25, 1), background-color .4s cubic-bezier(.25, .8, .25, 1);
+    border-radius: 50%;
+  }
+
+  #myuw-help__close-button:hover {
+    background-color: rgba(158, 158, 158, 0.2);
+  }
+
+  #help-button {
+    display: none;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    position: relative;
+    cursor: pointer;
+    min-height: 42px;
+    min-width: 42px;
+    height: 42px;
+    width: 42px;
+    user-select: none;
+    outline: none;
+    padding: 0;
+    border: 0;
+    border-radius: 50%;
+    margin: 0 6px;
+    background-color: transparent;
+    -webkit-transition: background-color .3s cubic-bezier(.35, 0, .25, 1);
+    transition: background-color .3s cubic-bezier(.35, 0, .25, 1);
+  }
+
+  #help-icon {
+    color: var(--myuw-primary-color, #fff);
+    fill: var(--myuw-primary-color, #fff);
+    height: 30px;
+    width: 30px;
+  }
+
+  #help-button:hover {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+
+  #help-button:focus,
+  #help-button:active {
+    outline: 2px solid #5e9ed6;
+    outline: -webkit-focus-ring-color auto 5px;
+  }
+
+  @media all and (min-width: 481px) and (max-width: 840px) {
     #myuw-help__dialog {
-      display: none;
-        max-width: 80%;
-        min-width: 300px;
-        height: auto;
-        -webkit-box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
-        box-shadow: 0 -2px 25px 0 rgba(0, 0, 0, 0.15), 0 13px 25px 0 rgba(0, 0, 0, 0.3);
-        background-color: #FFFFFF;
-        padding: 22px 24px 12px;
-        margin-top: 0;
-        margin-bottom: 0;
-        margin-left: auto;
-        margin-right: auto;
-        border-radius: 5px;
-        font-family: 'Roboto', Arial, sans-serif; /* TODO: use styles variables */
-        opacity: 0;
-        position: absolute;
-        float: left;
-        top: 0;
-        right: -1000px; 
-        -webkit-transition: all .4s cubic-bezier(.25,.8,.25,1);
-        transition: all .4s cubic-bezier(.25,.8,.25,1);
-        z-index: 101;
+      width: 400px;
     }
+  }
 
-    #myuw-help__heading {
-        display: flex;
-        align-content: center;
-        justify-content: space-between;
+  @media all and (min-width: 841px) {
+    #myuw-help__dialog {
+      width: 600px;
     }
-
-    #myuw-help__title {
-        color: rgba(0,0,0,0.8);
-        font-size: 20px;
-        font-weight: 500;
-        line-height: 24px;
-        letter-spacing: 0.03px;
-    }
-
-    #myuw-help__content {
-        font-weight: 400;
-        font-size: 16px;
-        color: rgba(0,0,0,.8);
-        line-height: 24px;
-        text-align: left;
-        letter-spacing: 0.03px;
-        padding: 8px 0 16px;
-    }
-
-    #myuw-help__default-content {
-        display: none;
-    }
-
-    #myuw-help__default-content ul {
-        margin: 0;
-        padding: 0;
-        list-style-type: none;
-    }
-    #myuw-help__default-content ul li {
-        transition: background 0.4s cubic-bezier(.25,.8,.25,1);
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-        min-height: 38px;
-        height: auto;
-        padding: 0 16px 0 6px;
-    }
-    #myuw-help__default-content ul li:hover {
-        background: rgba(158,158,158,0.2);
-    }
-    #myuw-help__default-content a {
-        text-decoration: none;
-        color: #0479a8; /* TODO: use styles variables */
-        min-height: 38px;
-        line-height: 38px;
-        flex: auto;
-        display: flex;
-        align-items: center;
-    }
-
-    #myuw-help__default-content .material-icons {
-        width: 24px;
-        min-height: 24px;
-        min-width: 24px;
-        margin-right: 12px;
-        color: #434343;
-    }
-
-    #myuw-help__shadow {
-        position: fixed;
-        top: 64px;
-        left: 0;
-        width: 100%;
-        height: 0;
-        opacity: 0;
-        background: rgba(0,0,0,0.3);
-        transition: opacity 0.3s cubic-bezier(.25,.8,.25,1);
-        z-index: 100;
-    }
-
-    #myuw-help__close-button {
-        min-width: 48px;
-        max-width: 48px;
-        min-height: 48px;
-        max-height: 48px;
-        margin: 0;
-        display: flex;
-        -webkit-box-pack: center;
-        -ms-flex-pack: center;
-        -webkit-box-align: center;
-        -ms-flex-line-pack: center;
-        -ms-flex-align: center;
-	      justify-content:center;
-        align-content: center;
-        align-items: center;
-        position: relative;
-        cursor: pointer;
-        border-radius: 3px;
-        box-sizing: border-box;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-        border: 0;
-        padding: 0 6px;
-        background: transparent;
-        white-space: nowrap;
-        text-transform: uppercase;
-        font-weight: 500;
-        font-size: 14px;
-        text-decoration: none;
-        overflow: hidden;
-        -webkit-transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
-        transition: box-shadow .4s cubic-bezier(.25,.8,.25,1),background-color .4s cubic-bezier(.25,.8,.25,1);
-        border-radius: 50%;
-    }
-    #myuw-help__close-button:hover {
-        background-color: rgba(158,158,158,0.2);
-    }
-    #myuw-help__close-button:focus {
-        outline: none;
-    }
-
-    #help-button {
-      display: none;
-      justify-content: center;
-      align-content: center;
-      align-items: center;
-      position: relative;
-      cursor: pointer;
-      min-height: 42px;
-      min-width: 42px;
-      height: 42px;
-      width: 42px;
-      user-select: none;
-      outline: none;
-      padding: 0;
-      border: 0;
-      border-radius: 50%;
-      margin: 0 6px;
-      background-color: transparent;
-      -webkit-transition: background-color .3s cubic-bezier(.35,0,.25,1);
-      transition: background-color .3s cubic-bezier(.35,0,.25,1);
-    }
-
-    #help-icon {
-      color: var(--myuw-primary-color, #fff);
-      fill: var(--myuw-primary-color, #fff);
-      height: 30px;
-      width: 30px;
-    }
-
-    #help-button:hover {
-      background-color: rgba(0,0,0,0.2);
-    }
-
-    @media all and (min-width: 481px) and (max-width: 840px) {
-        #myuw-help__dialog {
-            width: 400px;
-        }
-    }
-
-    @media all and (min-width: 841px) {
-        #myuw-help__dialog {
-            width: 600px;
-        }
-    }
+  }
 </style>
-<button id="help-button" aria-label="open help dialog">
+<button id="help-button" aria-label="Open help dialog">
   <svg id="help-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
+    <path
+      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
+    <path d="M0 0h24v24H0z" fill="none" />
   </svg>
-    
 </button>
-<div id="myuw-help__dialog">
-    <div id="myuw-help__heading">
-        <h1 id="myuw-help__title"></h1>
-        <button id="myuw-help__close-button" aria-label="close dialog">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
-                <path d="M0 0h24v24H0z" fill="none"/>
-            </svg>
-        </button>
-    </div>
-    <div id="myuw-help__content">
-        <slot name="myuw-help-content"></slot>
-        <div id="myuw-help__default-content">
-            <ul>
-                <li>
-                    <a href="tel:608-264-4357">Call the help desk</a>
-                </li>
-                <li>
-                    <a href="mailto:help@doit.wisc.edu">Email the help desk</a>
-                </li>
-                <li>
-                    <a href="https://it.wisc.edu">Get help another way</a>
-                </li>
-                <li>
-                    <a href="https://outages.doit.wisc.edu/">Check the Outages page</a>
-                </li>
-                <li>
-                    <a href="https://kb.wisc.edu/">Search the KnowledgeBase</a>
-                </li>
-            </ul>
-        </div>
-    </div>
+
+<div id="myuw-help__dialog" role="dialog" aria-labelledby="myuw-help__title" aria-modal="true">
+  <div id="myuw-help__heading">
+    <h1 id="myuw-help__title"></h1>
+    <button id="myuw-help__close-button" aria-label="Close help dialog">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+        <path d="M0 0h24v24H0z" fill="none" />
+      </svg>
+    </button>
+  </div>
+  <div id="myuw-help__content">
+    <slot name="myuw-help-content">
+      <div id="myuw-help__default-content">
+        <ul>
+          <li>
+            <a href="tel:608-264-4357">Call the help desk</a>
+          </li>
+          <li>
+            <a href="mailto:help@doit.wisc.edu">Email the help desk</a>
+          </li>
+          <li>
+            <a href="https://it.wisc.edu">Get help another way</a>
+          </li>
+          <li>
+            <a href="https://outages.doit.wisc.edu/">Check the Outages page</a>
+          </li>
+          <li>
+            <a href="https://kb.wisc.edu/">Search the KnowledgeBase</a>
+          </li>
+        </ul>
+      </div>
+    </slot>
+  </div>
 </div>
 <div id="myuw-help__shadow"></div>

--- a/src/myuw-help.js
+++ b/src/myuw-help.js
@@ -1,119 +1,203 @@
 import tpl from './myuw-help.html';
+
 class MyUWHelp extends HTMLElement {
 
-  constructor() {
-    super();
-
-    // Create a shadowroot for this element
-    this.attachShadow({mode: 'open'});
-
-    // Append the custom HTML to the shadowroot
-    this.shadowRoot.appendChild(MyUWHelp.template.content.cloneNode(true));
+  static get elementName() {
+    return 'myuw-help';
   }
 
   static get observedAttributes() {
     return [
       'myuw-help-title',
       'open',
-      'show-default-content',
-      'show-button'
+      'show-button',
+      'show-default-content'
+    ];
+  }
+
+  static get template() {
+    if (this._template===undefined) {
+      this._template=document.createElement('template');
+      this._template.innerHTML=tpl;
+    }
+    return this._template;
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.appendChild(this.constructor.template.content.cloneNode(true));
+    this.$customPosition={};
+    this.titleHeadingElement=this.shadowRoot.getElementById('myuw-help__title');
+    this.$button=this.shadowRoot.getElementById('help-button');
+    this.$dialog=this.shadowRoot.getElementById('myuw-help__dialog');
+    this.contentSlotElement=this.shadowRoot.querySelector('slot[name=myuw-help-content]');
+    this.$backdrop=this.shadowRoot.getElementById('myuw-help__shadow');
+    this.$dialogCloseButton=this.shadowRoot.getElementById('myuw-help__close-button');
+    this.eventListeners=[
+      { target: document, type: 'set-myuw-help-position', handler: event => this.handleDocumentSetHelpPosition(event) },
+      { target: document, type: 'show-myuw-help', handler: event => this.handleDocumentShowHelp(event) },
+      { target: this.$backdrop, type: 'click', handler: event => this.handleBackdropClick(event) },
+      { target: this.$button, type: 'click', handler: event => this.handleButtonClick(event) },
+      { target: this.$dialog, type: 'keydown', handler: event => this.handleDialogKeydown(event) },
+      { target: this.$dialogCloseButton, type: 'click', handler: event => this.handleDialogCloseButtonClick(event) }
     ];
   }
 
   /**
-  *   Web component lifecycle hook to update changed properties
-  */
-  attributeChangedCallback(name, oldValue, newValue) {
-    // Update the attribute internally
-    this[name] = newValue;
-    // Update the component
-    this.updateComponent();
-  }
-
-  /**
-  *   When component is first attached to the DOM,
-  *   get its defined attributes and set up listeners
-  */
-  connectedCallback() {
-    // Get all attributes
-    this['myuw-help-title']       = this.getAttribute('myuw-help-title');
-    this['open']                  = this.getAttribute('open');
-    this['show-default-content']  = this.getAttribute('show-default-content');
-    this['show-button']       = this.getAttribute('show-button');
-
-    this.$button            = this.shadowRoot.getElementById('help-button');
-    this.$dialog            = this.shadowRoot.getElementById('myuw-help__dialog');
-    this.$dialogTitle       = this.shadowRoot.getElementById('myuw-help__title');
-    this.$backdrop          = this.shadowRoot.getElementById('myuw-help__shadow');
-    this.$dialogCloseButton = this.shadowRoot.getElementById('myuw-help__close-button');
-    this.$customPosition    = {};
-
-    // Listen for open events and set positioning
-    this.$button.addEventListener('click', () => {
-      this.setDialogState();
-    });
-
-    document.addEventListener('show-myuw-help', () => {
-      this.setDialogState();
-    });
-
-    // Listen for custom positioning event
-    /**
-      * @typedef {Object} position
-      * @property {String} top A value for the CSS "top" attribute
-      * @property {String} left A value for the CSS "left" attribute
-    */
-    document.addEventListener('set-myuw-help-position', (data) => {
-      if (data.detail && data.detail.position) {
-        this.$customPosition = data.detail.position;
-      }
-    });
-
-    // Listen for close events
-    this.$backdrop.addEventListener('click', () => {
-      this.setDialogState(false);
-    });
-    this.$dialogCloseButton.addEventListener('click', () => {
-      this.setDialogState(false);
-    });
-  }
-
-  /**
-  *   Update the component state
-  */
-  updateComponent() {
-    this.shadowRoot.getElementById('myuw-help__title').innerHTML = this['myuw-help-title'];
-  }
-
-  /**
-   * Open or close the dialog, focus it if opened
-   * @param {string} newState Optional parameter, either 'open' or 'closed'
+   * Array of the focusable elements within the modal, with the close button last.
+   * Always expected to have length 1 or greater, because of the close button.
+   *
+   * @returns {Array<Element>}
    */
-  setDialogState(newState) {
-    switch(newState) {
-      case false:
-        // close the dialog
-        this.removeAttribute('open');
-        this.resetDialogPosition();
+  get focusableElements() {
+    const selector="a[href], input:not([disabled]), button:not([disabled]), button, select, textarea";
+    const focusableElements=this.contentSlotElement.assignedElements({ flatten: true })
+      .reduce(
+        (agg, node) => {
+          if (node.matches(selector)) {
+            agg.push(node);
+          }
+          else {
+            node.querySelectorAll(selector).forEach(each => agg.push(each));
+          }
+          return agg;
+        },
+        []
+      )
+      ;
+    focusableElements.push(this.$dialogCloseButton);
+    return focusableElements;
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    switch (name) {
+      case 'myuw-help-title':
+        this.titleHeadingElement.innerHTML=newValue;
         break;
-      case true:
-        // open the dialog
-        this.setAttribute('open', '');
-        this.setDialogPosition();
-        this.$dialog.focus();
-        break;
-      default:
-        if (this.hasAttribute('open')) {
-          // close the dialog
-          this.removeAttribute('open');
-          this.resetDialogPosition();
-        } else {
-          // open the dialog
-          this.setAttribute('open', '');
+      case 'open':
+        // opening
+        if (oldValue===null&&newValue!==null) {
           this.setDialogPosition();
-          this.$dialog.focus();
+          this.focusableElements[0].focus();
+          return;
+        }
+        // closing
+        if (oldValue!==null&&newValue===null) {
+          this.resetDialogPosition();
+        }
+        // no change in open/close state; do nothing
+        break;
+      case 'show-button':
+        break;
+      case 'show-default-content':
+        break;
+    }
+  }
+
+  connectedCallback() {
+    this.eventListeners.forEach(({ target, type, handler }) => target.addEventListener(type, handler));
+  }
+
+  disconnectedCallback() {
+    this.eventListeners.forEach(({ target, type, handler }) => target.removeEventListener(type, handler));
+  }
+
+  handleButtonClick(event) {
+    this.toggle();
+    event.preventDefault();
+  }
+
+  handleDocumentShowHelp(event) {
+    this.toggle();
+    event.preventDefault();
+  }
+
+  handleDocumentSetHelpPosition(event) {
+    if (event.detail&&event.detail.position) {
+      this.$customPosition=event.detail.position;
+    }
+    event.preventDefault();
+  }
+
+  handleDialogKeydown(event) {
+    switch (event.key) {
+      default:
+        return;
+      case 'Escape':
+        this.close();
+        break;
+      case 'Tab':
+        if (event.shiftKey) {
+          this.focusPrevious();
+        }
+        else {
+          this.focusNext();
         }
         break;
+      case 'ArrowDown':
+        this.focusNext();
+        break;
+      case 'ArrowUp':
+        this.focusPrevious();
+        break;
+    }
+    event.preventDefault();
+  }
+
+  handleBackdropClick(event) {
+    this.close();
+    event.preventDefault();
+  }
+
+  handleDialogCloseButtonClick(event) {
+    this.close();
+    event.preventDefault();
+  }
+
+  toggle() {
+    if (this.hasAttribute('open')) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open() {
+    this.setAttribute('open', '');
+  }
+
+  close() {
+    this.removeAttribute('open');
+  }
+
+  /**
+   * Focus the next option in the dialog, cycling around to the first
+   */
+  focusNext() {
+    const focusableElements=this.focusableElements;
+    const focusedElement=this.isSameNode(document.activeElement)? this.shadowRoot.activeElement:document.activeElement;
+    const focusedIndex=focusableElements.indexOf(focusedElement);
+    if (focusedIndex===focusableElements.length-1||focusedIndex===-1) {
+      focusableElements[0].focus();
+    }
+    else {
+      focusableElements[focusedIndex+1].focus();
+    }
+  }
+
+  /**
+   * Focus the previous option in the dialog, cycling around to the last (the close button)
+   */
+  focusPrevious() {
+    const focusableElements=this.focusableElements;
+    const focusedElement=this.isSameNode(document.activeElement)? this.shadowRoot.activeElement:document.activeElement;
+    const focusedIndex=focusableElements.indexOf(focusedElement);
+    if (focusedIndex===0||focusedIndex===-1) {
+      focusableElements[focusableElements.length-1].focus();
+    }
+    else {
+      focusableElements[focusedIndex-1].focus();
     }
   }
 
@@ -121,72 +205,45 @@ class MyUWHelp extends HTMLElement {
    * Position the dialog off-screen
    */
   resetDialogPosition() {
-    this.$dialog.style.top = 0;
-    this.$dialog.style.left = 'auto';
-    this.$dialog.style.right = '-1000px';
+    this.$dialog.style.top=0;
+    this.$dialog.style.left='auto';
+    this.$dialog.style.right='-1000px';
   }
 
   /**
    * Position the dialog in the middle of the screen
    */
   setDialogPosition() {
-    if (this.$customPosition.left && this.$customPosition.top) {
-      this.$dialog.style.left = this.$customPosition.left;
-      this.$dialog.style.top = this.$customPosition.top;
-      this.$dialog.style.right = 'auto';
-    } else {
-      // Dialog dimensions
-      var dialogWidth = this.$dialog.offsetWidth;
-      var dialogHeight = this.$dialog.offsetHeight;
-
-      // Screen dimensions
-      /*
-        These variables check to make sure mobile is supported and scroll bar is accounted for across browsers 
-      */
-      var cssWidth = window.innerWidth && document.documentElement.clientWidth 
-        ? Math.min(window.innerWidth, document.documentElement.clientWidth) : window.innerWidth || 
-        document.documentElement.clientWidth || 
-        document.getElementsByTagName('body')[0].clientWidth;
-      var cssHeight = window.innerHeight && document.documentElement.clientHeight 
-        ? Math.min(window.innerHeight, document.documentElement.clientHeight) : window.innerHeight || 
-        document.documentElement.clientHeight || 
-        document.getElementsByTagName('body')[0].clientHeight;
-
-      // Dialog position
-      var topPosition = ((cssHeight - dialogHeight) / 3);
-      var leftPosition = ((cssWidth - dialogWidth) / 2);;
-
-      // Set positioning
-      this.$dialog.style.left = leftPosition + 'px';
-      this.$dialog.style.top = topPosition + 'px';
-      this.$dialog.style.right = 'auto';
+    if (this.$customPosition.left&&this.$customPosition.top) {
+      this.$dialog.style.left=this.$customPosition.left;
+      this.$dialog.style.top=this.$customPosition.top;
+      this.$dialog.style.right='auto';
+      return;
     }
+    // Dialog dimensions
+    const dialogWidth=this.$dialog.offsetWidth;
+    const dialogHeight=this.$dialog.offsetHeight;
+    // Screen dimensions
+    // These variables check to make sure mobile is supported and scroll bar is accounted for across browsers
+    const cssWidth=window.innerWidth&&document.documentElement.clientWidth
+      ? Math.min(window.innerWidth, document.documentElement.clientWidth):window.innerWidth||
+      document.documentElement.clientWidth||
+      document.getElementsByTagName('body')[0].clientWidth;
+    const cssHeight=window.innerHeight&&document.documentElement.clientHeight
+      ? Math.min(window.innerHeight, document.documentElement.clientHeight):window.innerHeight||
+      document.documentElement.clientHeight||
+      document.getElementsByTagName('body')[0].clientHeight;
+    // Dialog position
+    const topPosition=((cssHeight-dialogHeight)/3);
+    const leftPosition=((cssWidth-dialogWidth)/2);
+    // Set positioning
+    this.$dialog.style.left=leftPosition+'px';
+    this.$dialog.style.top=topPosition+'px';
+    this.$dialog.style.right='auto';
   }
+
 }
 
-MyUWHelp.template = (function template(src) {
-  const template = (document.createElement('template'));
-  template.innerHTML = src;
-  return template;
-})(tpl);
-
-/**
- * Polyfill for supporting the CustomEvent constructor in IE9+
- * From: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
- */
-(function () {
-  if (typeof window.CustomEvent === 'function') {
-    return false;
-  }
-  
-  function CustomEvent (event, params) {
-    params = params || { bubbles: false, cancelable: false, detail: undefined };
-    var evt = document.createEvent( 'CustomEvent' );
-    evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
-    return evt;
-  }
-  CustomEvent.prototype = window.Event.prototype;
-  window.CustomEvent = CustomEvent;
-})();
-
-window.customElements.define('myuw-help', MyUWHelp);
+if (customElements.get(MyUWHelp.elementName)===undefined) {
+  customElements.define(MyUWHelp.elementName, MyUWHelp);
+}


### PR DESCRIPTION
**1.5.0**

**Added**
- Appropriate style to the Help Button to indicate focus and active states
- Event listener that will close the Help Dialog after pressing escape key
- Create a focusNext() and focusPrevious() functions that will keep the focus within the Help Dialog while it's active

**Changed**
- Improve Open/Close Dialog labels for assistive technologies users

This PR contains approved changes submitted in this [PR](https://github.com/nogalpaulina/myuw-help/pull/1).