### PR TITLE
Fix dialog position outside of :host() pseudo-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-help versions
 
+## 1.5.2
+
+2020-03-05
+
+* Cross browser support for styles outside of :host() pseudo-class which isn't supported by older IE and Edge versions
+
 ## 1.5.1
 
 2020-01-15

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "module": "dist/myuw-help.min.mjs",
   "browser": "dist/myuw-help.min.js",

--- a/src/myuw-help.html
+++ b/src/myuw-help.html
@@ -52,11 +52,12 @@
   myuw-help[open] #myuw-help__dialog {
     opacity: 1;
     display: block;
+    position: fixed;
   }
 
   myuw-help[open] #myuw-help__shadow {
     opacity: 1;
-    /* height: 100%; */
+    height: 100%;
   }
 
   #myuw-help__dialog {


### PR DESCRIPTION
**1.5.2**

- Cross browser support for styles outside of :host() pseudo-class which isn't supported by older IE and Edge versions