### PR TITLE
build: remove Analyze step and its sonarqube integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,14 +11,6 @@ pipeline {
       }
     }
 
-    stage('Analyze') {
-      steps {
-        withCredentials([string(credentialsId: 'sonarqube-analysis-token', variable: 'TOKEN')]) {
-          sh 'npm run sonar -- -Dsonar.host.url=https://ia-tools-sonarqube.doit.wisc.edu/ -Dsonar.login="$TOKEN"'
-        }
-      }
-    }
-
     stage('Publish PR Version') {
       when { changeRequest() }
       environment {


### PR DESCRIPTION
Remove the Analyze step and its sonarqube integration,  because ia-tools-sonarqube is not available and so is breaking our process for publishing new versions of this web component to the cdn.my.wisc.edu ad-hoc CDN.

No version change because this is a meta build process change rather than a change to the Web Component software product as exposed outward.