### PR TITLE
Adjust position of the shadow behind the dialog content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # myuw-help versions
 
+## 1.5.3
+
+2020-04-23
+
+* Adjust position of the shadow behind the dialog, to ensure entire content is covered
+
 ## 1.5.2
 
 2020-03-05

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-help",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "module": "dist/myuw-help.min.mjs",
   "browser": "dist/myuw-help.min.js",

--- a/src/myuw-help.html
+++ b/src/myuw-help.html
@@ -150,7 +150,7 @@
 
   #myuw-help__shadow {
     position: fixed;
-    top: 64px;
+    top: 0;
     left: 0;
     width: 100%;
     height: 0;


### PR DESCRIPTION
## 1.5.3

* Adjust position of the shadow behind the dialog content, to ensure entire content is covered

<img width="1304" alt="Screen Shot 2020-04-23 at 3 22 51 PM" src="https://user-images.githubusercontent.com/10341961/80145997-b8209680-8576-11ea-8c63-edaac0975a1d.png">

<img width="1303" alt="Screen Shot 2020-04-23 at 3 23 06 PM" src="https://user-images.githubusercontent.com/10341961/80146004-bb1b8700-8576-11ea-8400-5399770ef347.png">

